### PR TITLE
Allow to set the route within options

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,17 @@ module.exports = function proxyMiddleware(options) {
   options.hostname = options.hostname;
   options.port = options.port;
   return function (req, resp, next) {
+    var url = req.url;
+    // You can pass the route within the options, as well
     if (typeof options.route === 'string') {
-      if (req.url.slice(0, options.route.length) !== options.route) {
+      var route = slashJoin(options.route, '');
+      if (url.slice(0, route.length) === route) {
+        url = url.slice(route.length);
+      } else {
         return next();
       }
     }
-    options.path = slashJoin(options.pathname, req.url);
+    options.path = slashJoin(options.pathname, url);
     options.method = req.method;
     options.headers = options.headers ? extend(req.headers, options.headers) : req.headers;
     var myReq = request(options, function (myRes) {


### PR DESCRIPTION
Grunt initializes connect with [middlewares as function arguments](https://github.com/senchalabs/connect/blob/master/lib/connect.js#L71), therefore the only way to pass the route is to write it to the options.

With this patch you can add a `route` string to the option and it goes next if it is outside that.

``` javascript
var proxyOptions = url.parse('http://localhost');
proxyOptions.route = '/api/';

var app = connect(proxy(proxyOptions));
```
