### PR TITLE
Added support for via header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ app.use('/api', proxy(url.parse('https://example.com/endpoint')));
 
 Other options:
 - `route`: you can pass the route for connect middleware within the options, as well.
+- `via`: by default no [via header](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45) is added. If you pass `true` for this option the local hostname will be used for the via header. You can also pass a string for this option in which case that will be used for the via header.
 
 ### Usage with route:
 


### PR DESCRIPTION
This adds [via header](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45) support to resolve #4. I thought it was safest to make this opt-in to avoid breaking any existing implementations where the via header may cause an issue for whatever reason - e.g. I noticed that you had removed the host header because of a dotcloud issue and I wanted to avoid any similar problems. It might be more 'correct' to make it opt out, as [the W3C 'via' spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45) says that this header is mandatory for gateways and proxies. Let me know if you want it opt-out instead and I can change it.
