### PR TITLE
Set default pathname to '/' instead of erroring out

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = function proxyMiddleware(options) {
   options = options || {};
   options.hostname = options.hostname;
   options.port = options.port;
+  options.pathname = options.pathname || '/';
 
   return function (req, resp, next) {
     var url = req.url;


### PR DESCRIPTION
I was trying this library out and discovered that if pathname was undefined, it would error out with `TypeError: Cannot read property 'length' of undefined` on https://github.com/badunk/node-proxy-middleware/blob/master/index.js#L117 coming from https://github.com/badunk/node-proxy-middleware/blob/master/index.js#L37

Just setting the default pathname to '/' if one isn't set from this PR.