### PR TITLE
adding support for string only parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ var proxy = require('proxy-middleware');
 var app = connect();
 app.use('/api', proxy(url.parse('https://example.com/endpoint')));
 // now requests to '/api/x/y/z' are proxied to 'https://example.com/endpoint/x/y/z'
+
+//same as example above but also uses a short hand string only parameter
+app.use('/api-string-only', proxy('https://example.com/endpoint'));
 ```
 
 ### Documentation:

--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ module.exports = function proxyMiddleware(options) {
 
   var httpLib = options.protocol === 'https:' ? https : http;
   var request = httpLib.request;
+
+  //enable ability to quickly pass a url for shorthand setup
+  if(typeof options === 'string'){
+    options = require('url').parse(options);
+  }
   options = options || {};
   options.hostname = options.hostname;
   options.port = options.port;


### PR DESCRIPTION
This enables configuration based middleware to use your great library easier.  An example would be a kraken.js application where [meddleware.js](https://github.com/krakenjs/meddleware) is used.  An example config using meddleware would be...

```js
"apiProxy": {
    "enabled": true,
    "route": "/api",
    "module": {
        "name": "proxy-middleware",
        "arguments": [ "http://jsontest.com" ]
    }
}
```