### PR TITLE
Bugfix http lib choice correction

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,14 +4,15 @@ var https = require('https');
 var owns = {}.hasOwnProperty;
 
 module.exports = function proxyMiddleware(options) {
+    
+  //enable ability to quickly pass a url for shorthand setup
+  if(typeof options === 'string'){
+      options = require('url').parse(options);
+  }
 
   var httpLib = options.protocol === 'https:' ? https : http;
   var request = httpLib.request;
 
-  //enable ability to quickly pass a url for shorthand setup
-  if(typeof options === 'string'){
-    options = require('url').parse(options);
-  }
   options = options || {};
   options.hostname = options.hostname;
   options.port = options.port;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var https = require('https');
 var owns = {}.hasOwnProperty;
 
 module.exports = function proxyMiddleware(options) {
-    
   //enable ability to quickly pass a url for shorthand setup
   if(typeof options === 'string'){
       options = require('url').parse(options);


### PR DESCRIPTION
Found a small problem when using the shorthand configuration method for HTTPS.  At the time the options are deduced from the URL, the httpLib has already been chosen and defaulted to HTTP.  If a HTTPS URL was specified then an error is generated when the HTTP lib attempts to process the HTTPS URL.

Swapping the order of the httpLib and url.parse logic solves this.