### PR TITLE
http rfc location header rewrite on 10.2.2 201 Created response from …

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function proxyMiddleware(options) {
         , headers = myRes.headers
         , location = headers.location;
       // Fix the location
-      if (statusCode > 300 && statusCode < 304 && location && location.indexOf(options.href) > -1) {
+      if (((statusCode > 300 && statusCode < 304) || statusCode === 201) && location && location.indexOf(options.href) > -1) {
         // absoulte path
         headers.location = location.replace(options.href, slashJoin('', slashJoin((options.route || ''), '')));
       }


### PR DESCRIPTION
…proxied server.

According to the spec http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html on 201 HTTP response (resource created succesfully):  "The newly created resource can be referenced by the URI(s) returned in the entity of the response, with the most specific URI for the resource given by a Location header field"

My backend colleagues use the 201 response with a location header for exactly this described use case. It would be great if node-proxy-middleware could respect this feature by also overriding the Location header - if it exists - on a 201 response.

However, I would not feel fatally injured should you choose to deny this pull request, because of potential implications I do not right now oversee.

Best & kind regards,
René