### PR TITLE
slashJoin() enhancement

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,9 +119,14 @@ function rewriteCookieHosts(existingHeaders, opts, applyTo, req) {
 }
 
 function slashJoin(p1, p2) {
-  if (p1.length && p1[p1.length - 1] === '/') {p1 = p1.substring(0, p1.length - 1); }
+  var trailing_slash = false;
+  if (p1.length && p1[p1.length - 1] === '/') {
+    p1 = p1.substring(0, p1.length - 1);
+    trailing_slash = true;
+  }
   if (p2.length && p2[0] === '/') {p2 = p2.substring(1); }
-  return p1 + '/' + p2;
+
+  return trailing_slash ? p1 + '/' + p2 : p1 + p2;
 }
 
 function extend(obj, src) {

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function proxyMiddleware(options) {
       // Fix the location
       if (((statusCode > 300 && statusCode < 304) || statusCode === 201) && location && location.indexOf(options.href) > -1) {
         // absoulte path
-        headers.location = location.replace(options.href, slashJoin('', slashJoin((options.route || ''), '')));
+        headers.location = location.replace(options.href, slashJoin('/', slashJoin((options.route || ''), '')));
       }
       applyViaHeader(myRes.headers, opts, myRes.headers);
       rewriteCookieHosts(myRes.headers, opts, myRes.headers, req);
@@ -120,13 +120,11 @@ function rewriteCookieHosts(existingHeaders, opts, applyTo, req) {
 
 function slashJoin(p1, p2) {
   var trailing_slash = false;
-  if (p1.length && p1[p1.length - 1] === '/') {
-    p1 = p1.substring(0, p1.length - 1);
-    trailing_slash = true;
-  }
-  if (p2.length && p2[0] === '/') {p2 = p2.substring(1); }
 
-  return trailing_slash ? p1 + '/' + p2 : p1 + p2;
+  if (p1.length && p1[p1.length - 1] === '/') { trailing_slash = true; }
+  if (trailing_slash && p2.length && p2[0] === '/') {p2 = p2.substring(1); }
+
+  return p1 + p2;
 }
 
 function extend(obj, src) {

--- a/test/test.js
+++ b/test/test.js
@@ -539,7 +539,7 @@ describe("proxy", function() {
       var options = url.parse('http://localhost:8084/foo/test/');
 
       http.get(options, function (res) {
-        assert.strictEqual('/foo/redirect/', res.headers.location);
+        assert.strictEqual(res.headers.location, '/foo/redirect/');
         done();
       }).on('error', function () {
         assert.fail('Request proxy failed');

--- a/test/test.js
+++ b/test/test.js
@@ -338,7 +338,7 @@ describe("proxy", function() {
     });
   });
 
-  it("correctly apllies the location header to the response when the response status code is 3xx", function(done) {
+  it("correctly applies the location header to the response when the response status code is 3xx", function(done) {
     var destServer = createServerWithLibName('http', function(req, resp) {
       resp.statusCode = 302;
       resp.setHeader('location', 'http://localhost:8055/foo/redirect/');

--- a/test/test.js
+++ b/test/test.js
@@ -521,7 +521,7 @@ describe("proxy", function() {
     });
   });
 
-  it("correctly apllies the location header to the response when the response status code is 201", function(done) {
+  it("correctly applies the location header to the response when the response status code is 201", function(done) {
     var destServer = createServerWithLibName('http', function(req, resp) {
       resp.statusCode = 201;
       resp.setHeader('location', 'http://localhost:8085/foo/redirect/');

--- a/test/test.js
+++ b/test/test.js
@@ -356,7 +356,7 @@ describe("proxy", function() {
       var options = url.parse('http://localhost:8054/foo/test/');
 
       http.get(options, function (res) {
-        assert.strictEqual('/foo/redirect/', res.headers.location);
+        assert.strictEqual(res.headers.location, '/foo/redirect/');
         done();
       }).on('error', function () {
         assert.fail('Request proxy failed');


### PR DESCRIPTION
modified slashJoin() to maintain trailing slashes in the path of a URL if they are already there, if they aren't there, we don't want to add it.  This PR adds logic to handle this properly.  Please see issue #43 for reference