### PR TITLE
actual fix for issue #43

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,9 +123,8 @@ function rewriteCookieHosts(existingHeaders, opts, applyTo, req) {
 }
 
 function slashJoin(p1, p2) {
-  if (p1.length && p1[p1.length - 1] === '/') {p1 = p1.substring(0, p1.length - 1); }
-  if (p2.length && p2[0] === '/') {p2 = p2.substring(1); }
-  return p1 + '/' + p2;
+  if (p1.length && p1[p1.length - 1] === '/' && p2.length && p2[0] === '/') {p2 = p2.substring(1); }
+  return p1 + p2;
 }
 
 function extend(obj, src) {


### PR DESCRIPTION
reverted slashJoin function, the faulty logic was outside the function, I added a new case check for req.url URLs that contain '/?query=param' as well as '?query=param', tests pass.  Closes #43 after merge, bump, and publish.
