### PR TITLE
Added options for transformReq and transformResp functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Other options:
 - `via`: by default no [via header](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45) is added. If you pass `true` for this option the local hostname will be used for the via header. You can also pass a string for this option in which case that will be used for the via header.
 - `cookieRewrite`: this option can be used to support cookies via the proxy by rewriting the cookie domain to that of the proxy server. By default cookie domains are not rewritten. The `cookieRewrite` option works as the `via` option - if you pass `true` the local hostname will be used, and if you pass a string that will be used as the rewritten cookie domain.
 - `preserveHost`: When enabled, this option will pass the Host: line from the incoming request to the proxied host. Default: `false`.
+- `transformReq`: transform function called on requests enables dynamic rewriting of headers sent to the server.
+- `transformResp`: transform function called on responses enables dynamic rewriting of headers coming back from the server.
 
 ### Usage with route:
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function proxyMiddleware(options) {
     opts.headers = options.headers ? merge(req.headers, options.headers) : req.headers;
 
     applyViaHeader(req.headers, opts, opts.headers);
+    transformReq(req.headers, opts, opts.headers);
 
     if (!options.preserveHost) {
       // Forwarding the host breaks dotcloud
@@ -64,6 +65,7 @@ module.exports = function proxyMiddleware(options) {
       }
       applyViaHeader(myRes.headers, opts, myRes.headers);
       rewriteCookieHosts(myRes.headers, opts, myRes.headers, req);
+      transformResp(myRes.headers, opts, myRes.headers);
       resp.writeHead(myRes.statusCode, myRes.headers);
       myRes.on('error', function (err) {
         next(err);
@@ -116,6 +118,22 @@ function rewriteCookieHosts(existingHeaders, opts, applyTo, req) {
   }
 
   applyTo['set-cookie'] = rewrittenCookies;
+}
+
+function transformReq (existingHeaders, opts, applyTo) {
+  if (typeof opts.transformReq !== 'function') {
+    return;
+  }
+
+  opts.transformReq(existingHeaders, opts, applyTo);
+}
+
+function transformResp (existingHeaders, opts, applyTo) {
+  if (typeof opts.transformResp !== 'function') {
+    return;
+  }
+
+  opts.transformResp(existingHeaders, opts, applyTo);
 }
 
 function slashJoin(p1, p2) {


### PR DESCRIPTION
Added options for `transformReq` and `transformResp` functions. This allows dynamic modification of request and response headers. It's based on the fork by @rjferguson21 (https://github.com/rjferguson21/node-proxy-middleware).

To give a real life example, I need this to add an `X-Forwarded-Host` header which must be the same as the `Host` header. This needs to be dynamic (localhost or network hostname) so can't be hardcoded in options.headers.
