### PR TITLE
Handle absolute paths without domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,9 +58,14 @@ module.exports = function proxyMiddleware(options) {
         , headers = myRes.headers
         , location = headers.location;
       // Fix the location
-      if (((statusCode > 300 && statusCode < 304) || statusCode === 201) && location && location.indexOf(options.href) > -1) {
-        // absoulte path
-        headers.location = location.replace(options.href, slashJoin('/', slashJoin((options.route || ''), '')));
+      if (((statusCode > 300 && statusCode < 304) || statusCode === 201) && location) {
+          // absolute path with domain
+          if(location.indexOf(options.href) > -1) {
+            headers.location = location.replace(options.href, slashJoin('/', slashJoin((options.route || ''), '')));
+          // absolute path without domain
+          } else if(location[0] === '/' && req.originalUrl.slice(req.url.length*-1) === req.url) {
+            headers.location = req.originalUrl.slice(0, req.url.length*-1) + headers.location;
+          }
       }
       applyViaHeader(myRes.headers, opts, myRes.headers);
       rewriteCookieHosts(myRes.headers, opts, myRes.headers, req);


### PR DESCRIPTION
Not sure of the implications, but it was useful for me to handle redirects to absolute urls that have no domain by appending the `headers.location` to the `req.originalUrl` minus the `req.url`.

More details here: http://stackoverflow.com/questions/36534971/node-express-proxy-middleware-handle-redirect
