### PR TITLE
Support `body` with req.write()

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,12 @@ module.exports = function proxyMiddleware(options) {
       });
       myRes.pipe(resp);
     });
+
+    if (options.body) {
+      myReq.write(options.body);
+    }
+
+
     myReq.on('error', function (err) {
       next(err);
     });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "proxy-middleware",
+  "name": "proxy-middleware-fork",
   "version": "0.15.0",
   "description": "http(s) proxy as connect middleware",
   "main": "index.js",


### PR DESCRIPTION
Not sure if this is something you are interested in, but I needed to be able to pass through JSON from a request. It doesn't seem that you guys use the `write` method at all. So this uses that if `body` is specified on the option.

For example:

```
proxy({
  ...
  body: JSON.stringify(req.body),
});
```
