### PR TITLE
Added suppressHttpAuthPopup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Other options:
 - `via`: by default no [via header](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.45) is added. If you pass `true` for this option the local hostname will be used for the via header. You can also pass a string for this option in which case that will be used for the via header.
 - `cookieRewrite`: this option can be used to support cookies via the proxy by rewriting the cookie domain to that of the proxy server. By default cookie domains are not rewritten. The `cookieRewrite` option works as the `via` option - if you pass `true` the local hostname will be used, and if you pass a string that will be used as the rewritten cookie domain.
 - `preserveHost`: When enabled, this option will pass the Host: line from the incoming request to the proxied host. Default: `false`.
+- `suppressHttpAuthPopup`: When enabled, upon getting the HTTP response status 401 (Unauthorized) from the proxied host, this option removes the `WWW-Authenticate` header from the proxy response, thus preventing the HTTP Authentication popup from appearing in some browsers. This is useful when  calling application itself handles the user authentication via the `Authorization` header. Default: `false`.
 
 ### Usage with route:
 

--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ module.exports = function proxyMiddleware(options) {
         // absoulte path
         headers.location = location.replace(options.href, slashJoin('/', slashJoin((options.route || ''), '')));
       }
+      if (statusCode === 401 && opts.suppressHttpAuthPopup) {
+        delete headers['www-authenticate'];
+      }
       applyViaHeader(myRes.headers, opts, myRes.headers);
       rewriteCookieHosts(myRes.headers, opts, myRes.headers, req);
       resp.writeHead(myRes.statusCode, myRes.headers);


### PR DESCRIPTION
This package almost fit all my needs and was missing just one minor feature, therefore - a pull request.

I've added the "suppressHttpAuthPopup" option when creating a proxy. When enabled, upon getting the HTTP response status 401 (Unauthorized) from the proxied host, this option removes the "WWW-Authenticate" header from the proxy response, thus preventing the HTTP Authentication popup from appearing in some browsers (got this in IE 11). This is useful when the calling application itself handles the user authentication via the "Authorization" header, instead of the server being insisting when the credentials are incorrect.